### PR TITLE
grizzled.config extensions

### DIFF
--- a/src/main/scala/grizzled/config/config.scala
+++ b/src/main/scala/grizzled/config/config.scala
@@ -510,6 +510,21 @@ class Configuration(predefinedSections: Map[String, Map[String, String]]) {
   }
 
   /**
+   * Get a string option as a List, using a comma as the separator.
+   *
+   * @param sectionName  the section name
+   * @param optionName   the option name
+   *
+   * @return The option's value if the section and option exist as a List[String]
+   */
+
+  def getStringAsList(sectionName: String, optionName: String): List[String] = {
+
+    for (value:String <- getOrElse(sectionName, optionName, "").split(",").toList)
+      yield value.trim
+  }
+
+  /**
    * Get an optional integer option.
    *
    * @param sectionName  the section name

--- a/src/test/scala/grizzled/config.scala
+++ b/src/test/scala/grizzled/config.scala
@@ -107,6 +107,23 @@ class ConfigTest extends FunSuite {
     }
   }
 
+  test("getStringAsList") {
+    val configText = """
+    |[section]
+    |var1 = val1, val2,val3,  val4
+    """.stripMargin
+
+    val data = Map("var1" -> List("val1", "val2", "val3", "val4"),
+                   "baz" -> List(""))
+    val config = Configuration(Source.fromString(configText))
+
+    for ((opt, expected) <- data) {
+      expect(expected, opt + " -> " + expected) {
+        config.getStringAsList("section", opt)
+      }
+    }
+  }
+
   test("legal getInt(), no default") {
     val configText = """
     |[section]


### PR DESCRIPTION
Hi Brian - I have a patch to add some features to grizzled.config:
- Accept # and . as part of the section name.
- Accept ; as a valid comment.
- Implement getStringAsList() - split on commas.
  (Should there be a corresponding getStringAsListOrElse() ?)
  (Should the separator be configurable?)

Your feedback is appreciated.

Thanks!
