### PR TITLE
MessageDigest fails with null bytes

### DIFF
--- a/src/main/scala/grizzled/security/MessageDigest.scala
+++ b/src/main/scala/grizzled/security/MessageDigest.scala
@@ -92,7 +92,7 @@ class Digester(dg: JMessageDigest) {
     dg.synchronized {
       dg.reset()
 
-      val buf = Array.ofDim[Byte](512)
+      val buf = Array.ofDim[Byte](8192)
       var readLen = stream.read(buf)
 
       while (readLen > 0) {

--- a/src/main/scala/grizzled/security/MessageDigest.scala
+++ b/src/main/scala/grizzled/security/MessageDigest.scala
@@ -3,7 +3,6 @@ package grizzled.security
 import java.io.{File, FileInputStream, InputStream}
 import java.security.{MessageDigest => JMessageDigest}
 
-import scala.annotation.tailrec
 import scala.io.Source
 
 import grizzled.string.{util => StringUtil}
@@ -91,17 +90,16 @@ class Digester(dg: JMessageDigest) {
     */
   def digest(stream: InputStream): Array[Byte] = {
     dg.synchronized {
+      dg.reset()
 
-      @tailrec def readNext(): Unit = {
-        val c = stream.read()
-        if (c >= 0) {
-          dg.update(c.toByte)
-          readNext()
-        }
+      val buf = Array.ofDim[Byte](512)
+      var readLen = stream.read(buf)
+
+      while (readLen > 0) {
+        dg.update(buf, 0, readLen)
+        readLen = stream.read(buf)
       }
 
-      dg.reset()
-      readNext()
       dg.digest
     }
   }

--- a/src/main/scala/grizzled/security/MessageDigest.scala
+++ b/src/main/scala/grizzled/security/MessageDigest.scala
@@ -94,7 +94,7 @@ class Digester(dg: JMessageDigest) {
 
       @tailrec def readNext(): Unit = {
         val c = stream.read()
-        if (c > 0) {
+        if (c >= 0) {
           dg.update(c.toByte)
           readNext()
         }

--- a/src/test/scala/grizzled/SecuritySpec.scala
+++ b/src/test/scala/grizzled/SecuritySpec.scala
@@ -9,8 +9,10 @@ import java.io.ByteArrayInputStream
  */
 class SecuritySpec extends BaseSpec {
   val Data = Array(
-    ("sha-256", "foo") -> "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
-    ("md5", "foo")     -> "acbd18db4cc2f85cedef654fccc4a4d8"
+    ("sha-256", "foo")  -> "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+    ("md5", "foo")      -> "acbd18db4cc2f85cedef654fccc4a4d8",
+    ("md5", "ab")       -> "187ef4436122d1cc2f40dc2b92f0eba0",
+    ("md5", "a\u0000b") -> "70350f6027bce3713f6b76473084309b"
   )
 
   "MessageDigest" should "work with string inputs" in {


### PR DESCRIPTION
I also changed it so it doesn't read bytes one-at-a-time as that's inefficient for large files.  Java's default buffer size seemed good to me so that's what I went with.